### PR TITLE
pathname修正

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -17,7 +17,7 @@ class Configuration
     private $database;
 
     /** @var string */
-    private $pathname = '/js/v3/event/';
+    private $pathname = '/postback/v3/event/';
 
     /**
      * @param array $options

--- a/tests/TreasureTest.php
+++ b/tests/TreasureTest.php
@@ -27,7 +27,7 @@ class TreasureTest extends TestCase
             ->method('request')
             ->with(
                 $this->equalTo('POST'),
-                $this->equalTo('https://in.treasuredata.com/js/v3/event/testdb/table'),
+                $this->equalTo('https://in.treasuredata.com/postback/v3/event/testdb/table'),
                 $this->equalTo([
                     'json' => ['hoge' => 'fuga'],
                     'headers' => ['X-TD-Write-Key' => 'testkey'],


### PR DESCRIPTION
## 概要

以下を利用しているが、
[Postback API – Arm Treasure Data](https://support.treasuredata.com/hc/en-us/articles/360000675487-Postback-API#POST%20%2Fpostback%2Fv3%2Fevent%2F%7Bdatabase%7D%2F%7Btable%7D)

そのpathは `/postback/v3/event/{database}/{table}` であるので修正する。

もしくは以下の言い方が適切かも：
今まではJS SDKのpathを利用していたが、
より適切なのは`/postback/v3/event/{database}/{table}` であるので修正する。


## テスト

* [x] テストコードが通る

```
composer install
vendor/bin/phpunit
````
