### PR TITLE
Support PHP 8.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,11 @@
             "Otobank\\Treasure\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Otobank\\Treasure\\Tests\\": "tests"
+        }
+    },
     "require": {
         "php": "^7.3 || ^8.0",
         "guzzlehttp/guzzle": "^7.2"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     },
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.2.5 || ^8.0",
         "guzzlehttp/guzzle": "^7.2"
     },
     "license": "MIT",
@@ -23,7 +23,7 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^8.5"
     },
     "scripts": {
         "test": "vendor/bin/phpunit"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         }
     },
     "require": {
-        "guzzlehttp/guzzle": "~6.0"
+        "php": "^7.3 || ^8.0",
+        "guzzlehttp/guzzle": "^7.2"
     },
     "license": "MIT",
     "authors": [
@@ -17,6 +18,6 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "^5.4"
+        "phpunit/phpunit": "^9.6"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,8 @@
     ],
     "require-dev": {
         "phpunit/phpunit": "^9.6"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -34,7 +34,7 @@ class Configuration
     }
 
     /**
-     * @var bool
+     * @param  bool          $development
      *
      * @return Configuration
      */
@@ -54,7 +54,8 @@ class Configuration
     }
 
     /**
-     * @return string        $host
+     * @param  string        $host
+     *
      * @return Configuration
      */
     public function setHost($host)

--- a/src/Treasure.php
+++ b/src/Treasure.php
@@ -35,6 +35,8 @@ class Treasure
     public function setClient(ClientInterface $client)
     {
         $this->client = $client;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
# Abstract

- [x] Update some dependencies to support PHP 8.0+
- [x] Because above breaks backward compatibility for PHP 7.2.4- unsupport PHP 7.2.4-
- [x] Fix some minor issues

# Testing

- [x] `composer test` passed
- [x] [Rector](https://github.com/rectorphp/rector) fixed nothing with following configuration (It means that code-base supports PHP from 7.2 to 8.2)

```php
$rectorConfig->paths([
    __DIR__ . '/src',
    __DIR__ . '/tests',
]);
$rectorConfig->sets([
    LevelSetList::UP_TO_PHP_82,
]);
$rectorConfig->phpVersion(PhpVersion::PHP_72);
```

# About versioning strategy

- IMHO, this PR should be release as **PATCH version up**
- refs:
    - https://twitter.com/koriym/status/782137756927406080
    - https://github.com/semver/semver/blob/2f5ef23b3e2cdbb12f75d94abb6f2061133e327b/semver.md#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api
- If some users are using this library with PHP 7.2.4-, the `composer update` will fail due to the `"php":"^7.2.5 || ^8.0"` statement, so there is no fear of soundlessly breaking the users' product

# Other

This PR also closes #6