### PR TITLE
Execute some tests on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,89 @@
+name: CI
+
+on: push
+
+jobs:
+  coding-standards:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+
+      - uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: |
+          composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+          composer bin all install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: Execute checks
+        run: composer cs
+
+  static-analysis:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php-version:
+          - 7.2
+          - 7.3
+          - 7.4
+          - 8.0
+          - 8.1
+          - 8.2
+
+    steps:
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: |
+          composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+          composer bin all install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: Execute checks
+        run: composer sa
+
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php-version:
+          - 7.2
+          - 7.3
+          - 7.4
+          - 8.0
+          - 8.1
+          - 8.2
+        dependencies:
+          - lowest
+          - highest
+
+    steps:
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - uses: actions/checkout@v3
+
+      - name: Install lowest dependencies
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: |
+          composer update -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist --prefer-lowest
+          # phpunit too old cannot be run on PHP 8.1+
+          composer update -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist phpunit/phpunit
+
+      - name: Install highest dependencies
+        if: ${{ matrix.dependencies == 'highest' }}
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: Execute tests
+        run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /vendor
 /vendor-bin/*/composer.lock
 /vendor-bin/*/vendor
+
+# friendsofphp/php-cs-fixer
+/.php-cs-fixer.php
+/.php-cs-fixer.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /composer.lock
 /vendor
+/vendor-bin/*/composer.lock
+/vendor-bin/*/vendor

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 # friendsofphp/php-cs-fixer
 /.php-cs-fixer.php
 /.php-cs-fixer.cache
+
+# phpunit/phpunit
+/phpunit.xml
+/.phpunit.result.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,15 @@
+<?php
+
+$finder = new PhpCsFixer\Finder();
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@Symfony' => true,
+        'yoda_style' => [
+            'equal' => false,
+            'identical' => false,
+            'less_and_greater' => false,
+        ],
+    ])
+    ->setFinder($finder)
+;

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -10,6 +10,7 @@ return (new PhpCsFixer\Config())
             'identical' => false,
             'less_and_greater' => false,
         ],
+        'no_null_property_initialization' => false,
     ])
     ->setFinder($finder)
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: php
-php:
-  - '5.6'
-  - '7.0'
-  - '7.1'
-  - '7.2'
-  - '7.3'
-install: composer install
-script: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 TreasureData REST API Wrapper
 =============================
 
-[![Build Status](https://travis-ci.org/otobank/treasure-php.svg?branch=master)](https://travis-ci.org/otobank/treasure-php)
+[![](https://github.com/otobank/treasure-php/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/otobank/treasure-php/actions/workflows/ci.yaml?query=branch:master)
 [![Latest Stable Version](https://poser.pugx.org/otobank/treasure/v/stable)](https://packagist.org/packages/otobank/treasure)
 [![Total Downloads](https://poser.pugx.org/otobank/treasure/downloads)](https://packagist.org/packages/otobank/treasure)
 [![Latest Unstable Version](https://poser.pugx.org/otobank/treasure/v/unstable)](https://packagist.org/packages/otobank/treasure)

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,16 @@
         "bamarni/composer-bin-plugin": "^1.8"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "cs": [
+            "@putenv PHP_CS_FIXER_IGNORE_ENV=1",
+            "vendor-bin/tools/vendor/bin/php-cs-fixer fix --config .php-cs-fixer.dist.php --dry-run --diff -v src tests"
+        ],
+        "cs:fix": [
+            "@putenv PHP_CS_FIXER_IGNORE_ENV=1",
+            "vendor-bin/tools/vendor/bin/php-cs-fixer fix --config .php-cs-fixer.dist.php src tests"
+        ],
+        "test": "vendor/bin/phpunit",
+        "tests": ["@cs", "@test"]
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,20 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^8.5",
+        "bamarni/composer-bin-plugin": "^1.8"
     },
     "scripts": {
         "test": "vendor/bin/phpunit"
+    },
+    "config": {
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true
+        }
+    },
+    "extra": {
+        "bamarni-bin": {
+            "bin-links": false
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,9 @@
             "@putenv PHP_CS_FIXER_IGNORE_ENV=1",
             "vendor-bin/tools/vendor/bin/php-cs-fixer fix --config .php-cs-fixer.dist.php src tests"
         ],
+        "sa": "@php -d memory_limit=-1 vendor-bin/tools/vendor/bin/phpstan analyse --configuration=phpstan.neon",
         "test": "vendor/bin/phpunit",
-        "tests": ["@cs", "@test"]
+        "tests": ["@cs", "@sa", "@test"]
     },
     "config": {
         "allow-plugins": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,3 +6,12 @@ parameters:
   paths:
     - src
     - tests
+
+  ignoreErrors:
+    # Allow some "Dynamic call to static method" in tests
+    # @see https://github.com/phpstan/phpstan-strict-rules/issues/36
+    - messages:
+        - '#Dynamic call to static method PHPUnit\\Framework\\TestCase::once\(\)\.#'
+        - '#Dynamic call to static method PHPUnit\\Framework\\Assert::equalTo\(\)\.#'
+      paths:
+        - tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+includes:
+  - vendor-bin/tools/vendor/phpstan/phpstan-strict-rules/rules.neon
+
+parameters:
+  level: max
+  paths:
+    - src
+    - tests

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Otobank\Treasure;
 
 class Configuration
@@ -19,6 +21,9 @@ class Configuration
     /** @var string */
     private $pathname = '/postback/v3/event/';
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function __construct(array $options = [])
     {
         foreach ($options as $key => $value) {
@@ -26,106 +31,66 @@ class Configuration
             if (!method_exists($this, $method)) {
                 throw new \InvalidArgumentException(sprintf('Unsupported options "%s"', $key));
             }
-            $this->$method($value);
+            $this->$method($value); // @phpstan-ignore-line
         }
     }
 
-    /**
-     * @param bool $development
-     *
-     * @return Configuration
-     */
-    public function setDevelopment($development)
+    public function setDevelopment(bool $development): self
     {
-        $this->development = $development ? true : false;
+        $this->development = $development;
 
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function getDevelopment()
+    public function getDevelopment(): bool
     {
         return $this->development;
     }
 
-    /**
-     * @param string $host
-     *
-     * @return Configuration
-     */
-    public function setHost($host)
+    public function setHost(string $host): self
     {
         $this->host = $host;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getHost()
+    public function getHost(): string
     {
         return $this->host;
     }
 
-    /**
-     * @var string
-     *
-     * @return Configuration
-     */
-    public function setWriteKey($writeKey)
+    public function setWriteKey(string $writeKey): self
     {
         $this->writeKey = $writeKey;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getWriteKey()
+    public function getWriteKey(): string
     {
         return $this->writeKey;
     }
 
-    /**
-     * @var string
-     *
-     * @return Configuration
-     */
-    public function setDatabase($database)
+    public function setDatabase(string $database): self
     {
         $this->database = $database;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getDatabase()
+    public function getDatabase(): string
     {
         return $this->database;
     }
 
-    /**
-     * @var string
-     *
-     * @return Configuration
-     */
-    public function setPathname($pathname)
+    public function setPathname(string $pathname): self
     {
         $this->pathname = $pathname;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getPathname()
+    public function getPathname(): string
     {
         return $this->pathname;
     }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -19,9 +19,6 @@ class Configuration
     /** @var string */
     private $pathname = '/postback/v3/event/';
 
-    /**
-     * @param array $options
-     */
     public function __construct(array $options = [])
     {
         foreach ($options as $key => $value) {
@@ -34,7 +31,7 @@ class Configuration
     }
 
     /**
-     * @param  bool          $development
+     * @param bool $development
      *
      * @return Configuration
      */
@@ -54,7 +51,7 @@ class Configuration
     }
 
     /**
-     * @param  string        $host
+     * @param string $host
      *
      * @return Configuration
      */

--- a/src/Treasure.php
+++ b/src/Treasure.php
@@ -28,8 +28,6 @@ class Treasure
     }
 
     /**
-     * @param ClientInterface $client
-     *
      * @return Treasure
      */
     public function setClient(ClientInterface $client)
@@ -41,7 +39,6 @@ class Treasure
 
     /**
      * @param string $table
-     * @param array  $record
      *
      * @return bool
      */

--- a/src/Treasure.php
+++ b/src/Treasure.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Otobank\Treasure;
 
 use GuzzleHttp\Client;
@@ -10,11 +12,11 @@ class Treasure
     /** @var Configuration */
     private $config;
 
-    /** @var ClientInterface */
-    private $client;
+    /** @var ClientInterface|null */
+    private $client = null;
 
     /**
-     * @param Configuration|array $config
+     * @param Configuration|array<string, mixed>|mixed $config
      */
     public function __construct($config = [])
     {
@@ -27,10 +29,7 @@ class Treasure
         }
     }
 
-    /**
-     * @return Treasure
-     */
-    public function setClient(ClientInterface $client)
+    public function setClient(ClientInterface $client): self
     {
         $this->client = $client;
 
@@ -38,13 +37,11 @@ class Treasure
     }
 
     /**
-     * @param string $table
-     *
-     * @return bool
+     * @param array<mixed> $record
      */
-    public function addRecord($table, array $record = [])
+    public function addRecord(string $table, array $record = []): bool
     {
-        if (!$this->client) {
+        if ($this->client === null) {
             $this->client = $this->createClient();
         }
 
@@ -65,10 +62,7 @@ class Treasure
         return $response->getStatusCode() === 200;
     }
 
-    /**
-     * @return ClientInterface
-     */
-    private function createClient()
+    private function createClient(): ClientInterface
     {
         return new Client();
     }

--- a/tests/TreasureTest.php
+++ b/tests/TreasureTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Otobank\Treasure\Tests;
 
 use GuzzleHttp\Client;
@@ -9,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class TreasureTest extends TestCase
 {
-    public function testDefaultConfiguration()
+    public function testDefaultConfiguration(): void
     {
         $t = new Treasure([
             'database' => 'testdb',

--- a/vendor-bin/tools/composer.json
+++ b/vendor-bin/tools/composer.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "php": "^7.2.5 || ^8.0"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.4"
+    }
+}

--- a/vendor-bin/tools/composer.json
+++ b/vendor-bin/tools/composer.json
@@ -3,6 +3,8 @@
         "php": "^7.2.5 || ^8.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.4"
+        "friendsofphp/php-cs-fixer": "^3.4",
+        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan-strict-rules": "^1.5"
     }
 }


### PR DESCRIPTION
# Abstract

This PR includes following changes:

- [x] Install [composer-bin-plugin](https://github.com/bamarni/composer-bin-plugin)
- [x] Install [php-cs-fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer) via composer-bin-plugin
- [x] Install [phpstan](https://github.com/phpstan/phpstan) via composer-bin-plugin
- [x] Fix some errors from php-cs-fixer and phpstan
- [x] Run php-cs-fixer, phpstan, and phpunit on GitHub Actions

# Result

See https://github.com/ttskch/treasure-php/actions/runs/5652323669

# Versioning

Because this PR doesn't include any BC-Breaking changes, it is recommended that it be released with **minor version bumping**. However, just some type hinting with PHPDoc is replaced with language-level type declarations, which may not work properly for users who ignore the type hinting and use it in an incorrect way.

# Note

The name of Composer scripts like `"cs"` and `"sa"` are inspired by [koriym/php-skeleton](https://github.com/koriym/Koriym.PhpSkeleton/blob/12f0a4ff5f30f23d40b689f4963884fbcaf08dda/composer.json#L34).

# Other

This PR also closes #8 